### PR TITLE
TinyMCE - Added filter `pip/tinymce/shortcodes` to let 3rd party add …

### DIFF
--- a/assets/js/tinymce-shortcodes.js
+++ b/assets/js/tinymce-shortcodes.js
@@ -272,6 +272,19 @@
                 }
 
                 // Add shortcode menu list
+                var pip_shortcodes_menu_items = [
+                    pip_field,
+                    pip_breadcrumb,
+                    pip_button,
+                    pip_button_group,
+                    pip_spacer,
+                    pip_title,
+                    pip_thumbnail
+                ];
+
+                // Add filter to allow 3rd party to add their own shortcodes
+                pip_shortcodes_menu_items = acf.applyFilters('pip/tinymce/shortcodes', pip_shortcodes_menu_items);
+
                 editor.addButton(
                     'pip_shortcodes',
                     function () {
@@ -279,15 +292,7 @@
                             type: 'menubutton',
                             text: 'Shortcodes',
                             tooltip: 'Shortcodes',
-                            menu: [
-                                pip_field,
-                                pip_breadcrumb,
-                                pip_button,
-                                pip_button_group,
-                                pip_spacer,
-                                pip_title,
-                                pip_thumbnail
-                            ],
+                            menu: pip_shortcodes_menu_items,
                             fixedWidth: true,
                         }
                     }


### PR DESCRIPTION
…their own shortcodes to the menu list 🚀

Like here for example:  

![image](https://user-images.githubusercontent.com/62112531/101181636-6a602680-364d-11eb-81e9-77e964a3fa50.png)
