### PR TITLE
PiloPress Fields with default value

### DIFF
--- a/includes/classes/admin/editor/class-button-field.php
+++ b/includes/classes/admin/editor/class-button-field.php
@@ -17,13 +17,13 @@ if ( !class_exists( 'PIP_Button_Field' ) ) {
             $this->label    = __( 'Button styles', 'pilopress' );
             $this->category = __( "Pilo'Press", 'pilopress' );
             $this->defaults = array(
-                'field_type'    => 'select',
-                'choices'       => array(),
-                'placeholder'   => '',
-                'return_format' => 'value',
+                'field_type'        => 'select',
+                'choices'           => array(),
+                'placeholder'       => '',
+                'return_format'     => 'value',
                 'pip_default_value' => '',
-                'allow_null'    => true,
-                'ajax'          => false,
+                'allow_null'        => true,
+                'ajax'              => false,
             );
 
             parent::__construct();

--- a/includes/classes/admin/editor/class-button-field.php
+++ b/includes/classes/admin/editor/class-button-field.php
@@ -42,8 +42,10 @@ if ( !class_exists( 'PIP_Button_Field' ) ) {
                 acf_enable_local();
             }
 
+            // Get class instance
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
+            // Add custom choices
             $choices       = array();
             $custom_styles = $pip_tinymce->get_custom_buttons();
             if ( $custom_styles ) {

--- a/includes/classes/admin/editor/class-font-color-field.php
+++ b/includes/classes/admin/editor/class-font-color-field.php
@@ -21,6 +21,7 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
                 'choices'       => array(),
                 'placeholder'   => '',
                 'return_format' => 'value',
+                'pip_default_value' => '',
                 'allow_null'    => true,
                 'other_choice'  => 0,
                 'allow_custom'  => 0,
@@ -39,6 +40,12 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
          */
         public function get_choices( $show_add_to_editor ) {
 
+            // Enable ACF "Local" mode if not active yet to get data from local fields
+            $acf_local_was_active = acf_is_local_enabled();
+            if ( !$acf_local_was_active ) {
+                acf_enable_local();
+            }
+
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
             $choices       = array();
@@ -55,6 +62,11 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
                 }
             }
 
+            // Restore ACF "Local" mode initial state after we get our data.
+            if ( !$acf_local_was_active ) {
+                acf_disable_local();
+            }
+
             return $choices;
         }
 
@@ -69,6 +81,13 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
 
             // Only show items with "Add to editor" option
             $show_add_to_editor = acf_maybe_get( $field, 'show_add_to_editor' );
+
+            // Default value
+            $field_default_value = acf_maybe_get( $field, 'pip_default_value' );
+            $field_value         = acf_maybe_get( $field, 'value' );
+            if ( !$field_value && $field_default_value ) {
+                $field['value'] = $field_default_value;
+            }
 
             $field['choices'] = $this->get_choices( $show_add_to_editor );
             $field['type']    = $field['field_type'];
@@ -267,11 +286,25 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
                 )
             );
 
+            // Select: Default value
+            acf_render_field_setting(
+                $field,
+                array(
+                    'label'         => __( 'Default Value', 'acf' ),
+                    'type'          => 'select',
+                    'name'          => 'pip_default_value',
+                    'required'      => 0,
+                    'allow_null'    => 1,
+                    'return_format' => 'value',
+                    'choices'       => $this->get_choices( 0 ),
+                )
+            );
+
             // Select: Type of class to return
             acf_render_field_setting(
                 $field,
                 array(
-                    'label'         => __( 'Return type', 'pilopress' ),
+                    'label'         => __( 'Return Value', 'acf' ),
                     'type'          => 'select',
                     'name'          => 'class_output',
                     'optgroup'      => true,

--- a/includes/classes/admin/editor/class-font-color-field.php
+++ b/includes/classes/admin/editor/class-font-color-field.php
@@ -17,15 +17,15 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
             $this->label    = __( 'Theme colors', 'pilopress' );
             $this->category = __( "Pilo'Press", 'pilopress' );
             $this->defaults = array(
-                'field_type'    => 'select',
-                'choices'       => array(),
-                'placeholder'   => '',
-                'return_format' => 'value',
+                'field_type'        => 'select',
+                'choices'           => array(),
+                'placeholder'       => '',
+                'return_format'     => 'value',
                 'pip_default_value' => '',
-                'allow_null'    => true,
-                'other_choice'  => 0,
-                'allow_custom'  => 0,
-                'ajax'          => false,
+                'allow_null'        => true,
+                'other_choice'      => 0,
+                'allow_custom'      => 0,
+                'ajax'              => false,
             );
 
             parent::__construct();

--- a/includes/classes/admin/editor/class-font-color-field.php
+++ b/includes/classes/admin/editor/class-font-color-field.php
@@ -46,8 +46,10 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
                 acf_enable_local();
             }
 
+            // Get class instance
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
+            // Add custom choices
             $choices       = array();
             $custom_styles = $pip_tinymce->get_custom_colors();
             if ( $custom_styles ) {
@@ -304,7 +306,7 @@ if ( !class_exists( 'PIP_Font_Color_Field' ) ) {
             acf_render_field_setting(
                 $field,
                 array(
-                    'label'         => __( 'Return Value', 'acf' ),
+                    'label'         => __( 'Return type', 'acf' ),
                     'type'          => 'select',
                     'name'          => 'class_output',
                     'optgroup'      => true,

--- a/includes/classes/admin/editor/class-font-family-field.php
+++ b/includes/classes/admin/editor/class-font-family-field.php
@@ -42,8 +42,10 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
                 acf_enable_local();
             }
 
+            // Get class instance
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
+            // Add custom choices
             $choices       = array();
             $custom_styles = $pip_tinymce->get_custom_fonts();
             if ( $custom_styles ) {

--- a/includes/classes/admin/editor/class-font-family-field.php
+++ b/includes/classes/admin/editor/class-font-family-field.php
@@ -17,13 +17,13 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
             $this->label    = __( 'Font family', 'pilopress' );
             $this->category = __( "Pilo'Press", 'pilopress' );
             $this->defaults = array(
-                'field_type'    => 'select',
-                'choices'       => array(),
-                'placeholder'   => '',
+                'field_type'        => 'select',
+                'choices'           => array(),
+                'placeholder'       => '',
                 'pip_default_value' => '',
-                'return_format' => 'value',
-                'allow_null'    => true,
-                'ajax'          => false,
+                'return_format'     => 'value',
+                'allow_null'        => true,
+                'ajax'              => false,
             );
 
             parent::__construct();

--- a/includes/classes/admin/editor/class-font-family-field.php
+++ b/includes/classes/admin/editor/class-font-family-field.php
@@ -20,6 +20,7 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
                 'field_type'    => 'select',
                 'choices'       => array(),
                 'placeholder'   => '',
+                'pip_default_value' => '',
                 'return_format' => 'value',
                 'allow_null'    => true,
                 'ajax'          => false,
@@ -35,6 +36,12 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
          */
         public function get_choices() {
 
+            // Enable ACF "Local" mode if not active yet to get data from local fields
+            $acf_local_was_active = acf_is_local_enabled();
+            if ( !$acf_local_was_active ) {
+                acf_enable_local();
+            }
+
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
             $choices       = array();
@@ -43,6 +50,11 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
                 foreach ( $custom_styles as $key => $custom_style ) {
                     $choices[ $key ] = $custom_style['name'];
                 }
+            }
+
+            // Restore ACF "Local" mode initial state after we get our data.
+            if ( !$acf_local_was_active ) {
+                acf_disable_local();
             }
 
             return $choices;
@@ -56,6 +68,13 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
          * @return mixed
          */
         public function prepare_field( $field ) {
+
+            // Default value
+            $field_default_value = acf_maybe_get( $field, 'pip_default_value' );
+            $field_value         = acf_maybe_get( $field, 'value' );
+            if ( !$field_value && $field_default_value ) {
+                $field['value'] = $field_default_value;
+            }
 
             $field['choices'] = $this->get_choices();
             $field['type']    = $field['field_type'];
@@ -116,6 +135,20 @@ if ( !class_exists( 'PIP_Font_Family_Field' ) ) {
                         'radio'    => __( 'Radio Buttons', 'acf' ),
                         'select'   => _x( 'Select', 'noun', 'acf' ),
                     ),
+                )
+            );
+
+            // Select: Default value
+            acf_render_field_setting(
+                $field,
+                array(
+                    'label'         => __( 'Default Value', 'acf' ),
+                    'type'          => 'select',
+                    'name'          => 'pip_default_value',
+                    'required'      => 0,
+                    'allow_null'    => 1,
+                    'return_format' => 'value',
+                    'choices'       => $this->get_choices(),
                 )
             );
 

--- a/includes/classes/admin/editor/class-font-style-field.php
+++ b/includes/classes/admin/editor/class-font-style-field.php
@@ -17,13 +17,13 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
             $this->label    = __( 'Font style', 'pilopress' );
             $this->category = __( "Pilo'Press", 'pilopress' );
             $this->defaults = array(
-                'field_type'    => 'select',
-                'choices'       => array(),
-                'placeholder'   => '',
+                'field_type'        => 'select',
+                'choices'           => array(),
+                'placeholder'       => '',
                 'pip_default_value' => '',
-                'return_format' => 'value',
-                'allow_null'    => true,
-                'ajax'          => false,
+                'return_format'     => 'value',
+                'allow_null'        => true,
+                'ajax'              => false,
             );
 
             parent::__construct();

--- a/includes/classes/admin/editor/class-font-style-field.php
+++ b/includes/classes/admin/editor/class-font-style-field.php
@@ -42,8 +42,10 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
                 acf_enable_local();
             }
 
+            // Get class instance
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
+            // Add custom choices
             $choices       = array();
             $custom_styles = $pip_tinymce->get_custom_typography();
             if ( $custom_styles ) {

--- a/includes/classes/admin/editor/class-font-style-field.php
+++ b/includes/classes/admin/editor/class-font-style-field.php
@@ -20,6 +20,7 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
                 'field_type'    => 'select',
                 'choices'       => array(),
                 'placeholder'   => '',
+                'pip_default_value' => '',
                 'return_format' => 'value',
                 'allow_null'    => true,
                 'ajax'          => false,
@@ -35,6 +36,12 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
          */
         public function get_choices() {
 
+            // Enable ACF "Local" mode if not active yet to get data from local fields
+            $acf_local_was_active = acf_is_local_enabled();
+            if ( !$acf_local_was_active ) {
+                acf_enable_local();
+            }
+
             $pip_tinymce = acf_get_instance( 'PIP_TinyMCE' );
 
             $choices       = array();
@@ -43,6 +50,11 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
                 foreach ( $custom_styles as $key => $custom_style ) {
                     $choices[ $key ] = $custom_style['name'];
                 }
+            }
+
+            // Restore ACF "Local" mode initial state after we get our data.
+            if ( !$acf_local_was_active ) {
+                acf_disable_local();
             }
 
             return $choices;
@@ -56,6 +68,13 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
          * @return mixed
          */
         public function prepare_field( $field ) {
+
+            // Default value
+            $field_default_value = acf_maybe_get( $field, 'pip_default_value' );
+            $field_value         = acf_maybe_get( $field, 'value' );
+            if ( !$field_value && $field_default_value ) {
+                $field['value'] = $field_default_value;
+            }
 
             $field['choices'] = $this->get_choices();
             $field['type']    = $field['field_type'];
@@ -116,6 +135,20 @@ if ( !class_exists( 'PIP_Font_Style_Field' ) ) {
                         'radio'    => __( 'Radio Buttons', 'acf' ),
                         'select'   => _x( 'Select', 'noun', 'acf' ),
                     ),
+                )
+            );
+
+            // Select: Default value
+            acf_render_field_setting(
+                $field,
+                array(
+                    'label'         => __( 'Default Value', 'acf' ),
+                    'type'          => 'select',
+                    'name'          => 'pip_default_value',
+                    'required'      => 0,
+                    'allow_null'    => 1,
+                    'return_format' => 'value',
+                    'choices'       => $this->get_choices(),
                 )
             );
 


### PR DESCRIPTION
Add `default_value` field settings for fields: 
- Color
- Font family
- Text style
- Button style

![image](https://user-images.githubusercontent.com/62112531/103363802-57117100-4abc-11eb-9e43-99ba1481799e.png)
