### PR TITLE
Fix #209 : return full path of font

### DIFF
--- a/includes/classes/admin/modules/class-tailwind.php
+++ b/includes/classes/admin/modules/class-tailwind.php
@@ -738,10 +738,9 @@ if ( !class_exists( 'PIP_Tailwind' ) ) {
                     // Get upload path
                     $post_id                    = $file['file']['ID'];
                     $attachment_upload_path     = wp_get_attachment_url( $post_id );
-                    $attachment_new_upload_path = strstr( $attachment_upload_path, '/wp-content' );
 
                     // Allow file URL to be override
-                    $font_url = apply_filters( 'pip/custom_font/url', site_url() . $attachment_new_upload_path, $attachment_new_upload_path );
+                    $font_url = apply_filters( 'pip/custom_font/url', $attachment_upload_path, $post_id );
 
                     // Store URL
                     $url[] = 'url(' . $font_url . ') format("' . $format . '")';

--- a/includes/classes/admin/modules/class-tailwind.php
+++ b/includes/classes/admin/modules/class-tailwind.php
@@ -56,7 +56,7 @@ if ( !class_exists( 'PIP_Tailwind' ) ) {
                     update_field(
                         'pip_tailwind_style_components',
                         array(
-                            'add_components_import'           => true,
+                            'add_components_import' => true,
                             'tailwind_style_after_components' => '',
                         ),
                         'pip_styles_tailwind_module'
@@ -66,7 +66,7 @@ if ( !class_exists( 'PIP_Tailwind' ) ) {
                     update_field(
                         'pip_tailwind_style_utilities',
                         array(
-                            'add_utilities_import'           => true,
+                            'add_utilities_import' => true,
                             'tailwind_style_after_utilities' => '',
                         ),
                         'pip_styles_tailwind_module'
@@ -736,11 +736,11 @@ if ( !class_exists( 'PIP_Tailwind' ) ) {
                     $format = $variable_font ? $format . '-variables' : $format;
 
                     // Get upload path
-                    $post_id                    = $file['file']['ID'];
-                    $attachment_upload_path     = wp_get_attachment_url( $post_id );
+                    $attachment_id          = $file['file']['ID'];
+                    $attachment_upload_path = wp_get_attachment_url( $attachment_id );
 
                     // Allow file URL to be override
-                    $font_url = apply_filters( 'pip/custom_font/url', $attachment_upload_path, $post_id );
+                    $font_url = apply_filters( 'pip/custom_font/url', $attachment_upload_path, $attachment_id );
 
                     // Store URL
                     $url[] = 'url(' . $font_url . ') format("' . $format . '")';


### PR DESCRIPTION
Fix for #209 

I propose another way to use the filter.

We return the media URL. If the user wants to use the filter, he has the URL and the post id.

Should that be enough?