### PR TITLE
ACF v6.0 UI fixes (Issue #224)

### DIFF
--- a/assets/css/pilopress-admin.css
+++ b/assets/css/pilopress-admin.css
@@ -316,6 +316,24 @@ body.admin_page_pip_styles_tailwind_module #publishing-action .spinner {
     border-top: 0;
 }
 
+/* ACF v.6.0 UI revamp fixes */
+
+/* Hiding add field on headerbar actions */
+.pip-builder .acf-headerbar-actions .add-field {
+    display: none;
+}
+
+/* Hiding all tabs from settings */
+.pip-builder .acf-tab-wrap {
+    display: none !important;
+}
+
+/* Making sure that the location field group is always shown */
+.pip-builder .field-group-locations {
+    display: block !important;
+}
+
+
 /* Pilo'Press: Layouts */
 
 /* Collection tag */

--- a/assets/css/pilopress-layout-admin.css
+++ b/assets/css/pilopress-layout-admin.css
@@ -39,3 +39,15 @@ div[data-name='hide_on_screen'] {
     padding: 0 !important;
     border: 0 !important;
 }
+
+/* ACF v.6.0 UI revamp fixes */
+
+/* Cancel the change of order between label and input in layout settings */
+.post-type-acf-field-group #pip_layout_settings .acf-field-true-false .acf-label {
+    order: inherit;
+}
+
+/* Fixing thumbnail text layout */
+#pip_layout_thumbnail .acf-field-image[data-name="_pip_thumbnail"] .acf-label {
+    display: block;
+}

--- a/includes/classes/admin/options-pages/styles-option-modules.php
+++ b/includes/classes/admin/options-pages/styles-option-modules.php
@@ -68,6 +68,7 @@ acf_add_local_field_group(
                         'ui'                => 1,
                         'ui_on_text'        => '',
                         'ui_off_text'       => '',
+                        'style'             => '',
                     ),
 
                     // TinyMCE
@@ -90,6 +91,7 @@ acf_add_local_field_group(
                         'ui'                => 1,
                         'ui_on_text'        => '',
                         'ui_off_text'       => '',
+                        'style'             => '',
                     ),
 
                     // AlpineJS
@@ -112,6 +114,7 @@ acf_add_local_field_group(
                         'ui'                => 1,
                         'ui_on_text'        => '',
                         'ui_off_text'       => '',
+                        'style'             => '',
                     ),
                     array(
                         'key'                        => 'field_alpinejs_version',

--- a/includes/classes/main/class-flexible-mirror.php
+++ b/includes/classes/main/class-flexible-mirror.php
@@ -104,7 +104,6 @@ if ( !class_exists( 'PIP_Flexible_Mirror' ) ) {
         public function meta_boxes() {
 
             // Remove meta boxes normal
-            remove_meta_box( 'acf-field-group-options', 'acf-field-group', 'normal' );
             remove_meta_box( 'acf-field-group-fields', 'acf-field-group', 'normal' );
             remove_meta_box( 'slugdiv', 'acf-field-group', 'normal' );
             remove_meta_box( 'acf-field-group-acfe', 'acf-field-group', 'normal' );


### PR DESCRIPTION
- `includes\classes\main\class-flexible-mirror.php` ---> removing the removal of the metabox containing the locations rules
- `includes\classes\admin\options-pages\styles-option-modules.php` ---> adding style attribute to avoid undefined index by ACFE
- CSS changes to make things more readable

#224 