### PR TITLE
Enhance error messages coming from Tailwind API server

### DIFF
--- a/includes/classes/admin/class-admin.php
+++ b/includes/classes/admin/class-admin.php
@@ -40,44 +40,41 @@ if ( !class_exists( 'PIP_Admin' ) ) {
             // Check if Tailwind configuration is overridden
             $tailwind_config = get_field( 'pip_tailwind_config', 'pip_styles_tailwind_module' );
             $override_config = acf_maybe_get( $tailwind_config, 'override_config' );
-            if ( $override_config && ( $current_admin_page === 'pip_styles_configuration' || $current_admin_page === 'pip_styles_fonts' ) ) :
-                ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TailwindCSS configuration is overridden.', 'pilopress' ); ?></b>
-                </p>
-                <p>
-                    <?php _e( '<code>Breakpoints</code> and <code>Container</code> tabs are useless.', 'pilopress' ); ?>
-                    <?php _e( '<code>Colors</code> tab is useful for TinyMCE module only.', 'pilopress' ); ?>
-                    <?php _e( "Font families won't be added automatically.", 'pilopress' ); ?>
-                </p>
-            </div>
+            if ( $override_config && ( $current_admin_page === 'pip_styles_configuration' || $current_admin_page === 'pip_styles_fonts' ) ) : ?>
+                <div class="notice notice-info is-dismissible">
+                    <p>
+                        <b><?php _e( 'TailwindCSS configuration is overridden.', 'pilopress' ); ?></b>
+                    </p>
+                    <p>
+                        <?php _e( '<code>Breakpoints</code> and <code>Container</code> tabs are useless.', 'pilopress' ); ?>
+                        <?php _e( '<code>Colors</code> tab is useful for TinyMCE module only.', 'pilopress' ); ?>
+                        <?php _e( "Font families won't be added automatically.", 'pilopress' ); ?>
+                    </p>
+                </div>
                 <?php
             endif;
 
             // If Tailwind module is deactivate
-            if ( !acf_maybe_get( $modules, 'tailwind' ) ) :
-                ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TailwindCSS module is disabled.', 'pilopress' ); ?></b>
-                    <br>
-                    <?php _e( "Stylesheets won't be generated automatically.", 'pilopress' ); ?>
-                </p>
-            </div>
+            if ( !acf_maybe_get( $modules, 'tailwind' ) ) : ?>
+                <div class="notice notice-info is-dismissible">
+                    <p>
+                        <b><?php _e( 'TailwindCSS module is disabled.', 'pilopress' ); ?></b>
+                        <br>
+                        <?php _e( "Stylesheets won't be generated automatically.", 'pilopress' ); ?>
+                    </p>
+                </div>
                 <?php
             endif;
 
             // If TinyMCE module is deactivate
-            if ( !acf_maybe_get( $modules, 'tinymce' ) ) :
-                ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TinyMCE module is disabled.', 'pilopress' ); ?></b>
-                    <br>
-                    <?php _e( "Typography, colors, buttons and fonts won't be available in editor.", 'pilopress' ); ?>
-                </p>
-            </div>
+            if ( !acf_maybe_get( $modules, 'tinymce' ) ) : ?>
+                <div class="notice notice-info is-dismissible">
+                    <p>
+                        <b><?php _e( 'TinyMCE module is disabled.', 'pilopress' ); ?></b>
+                        <br>
+                        <?php _e( "Typography, colors, buttons and fonts won't be available in editor.", 'pilopress' ); ?>
+                    </p>
+                </div>
                 <?php
             endif;
 
@@ -85,6 +82,7 @@ if ( !class_exists( 'PIP_Admin' ) ) {
             $compile_error_details_json = get_transient( 'pip_tailwind_api_compile_error' );
             $compile_success            = get_transient( 'pip_tailwind_api_compile_success' );
             $error_compile              = acf_maybe_get_GET( 'error_compile' );
+
             if ( $error_compile && $compile_error_details_json ) :
                 $error_details = json_decode( $compile_error_details_json, false );
                 $error_message = isset( $error_details[0] ) ? $error_details[0] : false;
@@ -109,7 +107,6 @@ if ( !class_exists( 'PIP_Admin' ) ) {
                 <?php
                 delete_transient( 'pip_tailwind_api_compile_success' );
             endif;
-
         }
 
         /**

--- a/includes/libs/tailwindapi.php
+++ b/includes/libs/tailwindapi.php
@@ -73,9 +73,21 @@ if ( !class_exists( 'TailwindAPI' ) ) {
 
             // Error
             if ( is_wp_error( $return ) ) {
-                set_transient( 'pip_tailwind_api_compile_error', __( 'An error occurred. Please try again later', 'pilopress' ), 45 );
+
+                // Get error messages
+                $api_reason_message = '';
+                $api_errors         = $return->errors ?? array();
+                foreach ( $api_errors as $api_error ) {
+                    $api_reason_message .= $api_reason_message ? PHP_EOL : '';
+                    $api_reason_message .= is_array( $api_error ) ? reset( $api_error ) : $api_error;
+                }
+
+                // Push it into the transient & redirect
+                $api_reason_message = wp_json_encode( array( $api_reason_message ) );
+                set_transient( 'pip_tailwind_api_compile_error', $api_reason_message, 45 );
                 wp_safe_redirect( add_query_arg( 'error_compile', 1, acf_get_current_url() ) );
                 exit();
+
             }
 
             // Error
@@ -273,7 +285,6 @@ if ( !class_exists( 'TailwindAPI' ) ) {
                                 ) {
                                     unset( $classes_match[ $class_index ] );
                                 }
-
                             }
 
                             $all_classes_match = array_unique( array_merge( $all_classes_match, $classes_match ) );

--- a/includes/views/styles-admin-page.php
+++ b/includes/views/styles-admin-page.php
@@ -29,84 +29,9 @@
         // Get modules
         $modules = pip_get_modules();
 
-        // Check if Tailwind configuration is overridden
-        $tailwind_config = get_field( 'pip_tailwind_config', 'pip_styles_tailwind_module' );
-        $override_config = acf_maybe_get( $tailwind_config, 'override_config' );
-
-        if ( $override_config && ( $current_page === 'pip-styles-configuration' || $current_page === 'pip-styles-fonts' ) ) : ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TailwindCSS configuration is overridden.', 'pilopress' ); ?></b>
-                </p>
-                <p>
-                    <?php _e( '<code>Breakpoints</code> and <code>Container</code> tabs are useless.', 'pilopress' ); ?>
-                    <?php _e( '<code>Colors</code> tab is useful for TinyMCE module only.', 'pilopress' ); ?>
-                    <?php _e( "Font families won't be added automatically.", 'pilopress' ); ?>
-                </p>
-            </div>
-        <?php endif; ?>
-
-        <?php
-        // If Tailwind module is deactivate
-        if ( !acf_maybe_get( $modules, 'tailwind' ) ) : ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TailwindCSS module is disabled.', 'pilopress' ); ?></b>
-                    <br>
-                    <?php _e( "Stylesheets won't be generated automatically.", 'pilopress' ); ?>
-                </p>
-            </div>
-        <?php endif; ?>
-
-        <?php
-        // If TinyMCE module is deactivate
-        if ( !acf_maybe_get( $modules, 'tinymce' ) ) : ?>
-            <div class="notice notice-info is-dismissible">
-                <p>
-                    <b><?php _e( 'TinyMCE module is disabled.', 'pilopress' ); ?></b>
-                    <br>
-                    <?php _e( "Typography, colors, buttons and fonts won't be available in editor.", 'pilopress' ); ?>
-                </p>
-            </div>
-        <?php endif; ?>
-
-        <?php
         wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false );
         wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
-        $compile_error   = get_transient( 'pip_tailwind_api_compile_error' );
-        $compile_success = get_transient( 'pip_tailwind_api_compile_success' );
         ?>
-
-        <?php
-        // Error message
-        if ( acf_maybe_get_GET( 'error_compile' ) && ( $compile_error ) ) :
-            $error_array   = json_decode( $compile_error, false );
-            $error_message = false;
-
-            if ( isset( $error_array[0] ) ) {
-                $error_message = $error_array[0];
-            }
-            ?>
-            <div class="notice notice-error is-dismissible">
-
-                <p><?php _e( 'An error occurred while compiling.', 'pilopress' ); ?></p>
-
-                <?php if ( $error_message ) : ?>
-                <pre style="margin-bottom:10px;"><?php echo $error_message; ?></pre>
-                <?php endif; ?>
-
-            </div>
-            <?php
-            delete_transient( 'pip_tailwind_api_compile_error' );
-        endif; ?>
-
-        <?php // Success message ?>
-        <?php if ( !acf_maybe_get_GET( 'error_compile' ) && ( $compile_success ) ) : ?>
-            <div class="notice notice-success is-dismissible">
-                <p><?php echo $compile_success; ?></p>
-            </div>
-            <?php delete_transient( 'pip_tailwind_api_compile_success' ); ?>
-        <?php endif; ?>
 
         <div id="poststuff">
             <div

--- a/includes/views/styles-admin-page.php
+++ b/includes/views/styles-admin-page.php
@@ -77,9 +77,9 @@
         $compile_success = get_transient( 'pip_tailwind_api_compile_success' );
         ?>
 
-        <?php // Error message ?>
-        <?php if ( acf_maybe_get_GET( 'error_compile' ) && ( $compile_error ) ) : ?>
-            <?php
+        <?php
+        // Error message
+        if ( acf_maybe_get_GET( 'error_compile' ) && ( $compile_error ) ) :
             $error_array   = json_decode( $compile_error, false );
             $error_message = false;
 
@@ -88,15 +88,17 @@
             }
             ?>
             <div class="notice notice-error is-dismissible">
+
                 <p><?php _e( 'An error occurred while compiling.', 'pilopress' ); ?></p>
 
                 <?php if ( $error_message ) : ?>
-                    <pre style="margin-bottom:10px;"><?php echo $error_message; ?></pre>
+                <pre style="margin-bottom:10px;"><?php echo $error_message; ?></pre>
                 <?php endif; ?>
 
             </div>
-            <?php delete_transient( 'pip_tailwind_api_compile_error' ); ?>
-        <?php endif; ?>
+            <?php
+            delete_transient( 'pip_tailwind_api_compile_error' );
+        endif; ?>
 
         <?php // Success message ?>
         <?php if ( !acf_maybe_get_GET( 'error_compile' ) && ( $compile_success ) ) : ?>


### PR DESCRIPTION
Display an advanced error message when Tailwind API server has an error now.
Like here for example when you have too much CSS to compile & server has a timeout too short:    

![image](https://user-images.githubusercontent.com/6544224/207362547-4fc5515d-17c8-44a5-9b86-28b5212bdf0a.png)
