### PR TITLE
Fix polylang patterns

### DIFF
--- a/includes/classes/admin/patterns/class-locked-content.php
+++ b/includes/classes/admin/patterns/class-locked-content.php
@@ -259,7 +259,7 @@ if ( !class_exists( 'PIP_Locked_Content' ) ) {
             }
 
             // Check if Polylang is active
-            $polylang = is_plugin_active( 'polylang/polylang.php' ) && function_exists( 'pll_get_post_language' );
+            $polylang = function_exists( 'pll_get_post_language' );
 
             // Get current language for Polylang
             $current_language = null;

--- a/includes/classes/admin/patterns/class-patterns.php
+++ b/includes/classes/admin/patterns/class-patterns.php
@@ -342,11 +342,16 @@ if ( !class_exists( 'PIP_Patterns' ) ) {
         private function auto_populate_post_types_polylang( $post_type, $template_post_id, $template_post_type ) {
 
             // Polylang Compatibility - Create translations
-            if ( is_plugin_active( 'polylang/polylang.php' ) && function_exists( 'pll_languages_list' ) ) {
+            if ( function_exists( 'pll_languages_list' ) ) {
 
                 $languages              = pll_languages_list();
                 $post_type_object       = get_post_type_object( $post_type );
                 $available_translations = array();
+
+                // Set language of main post to default value
+                if ( function_exists( 'pll_set_post_language' ) ) {
+                    pll_set_post_language( $template_post_id, pll_default_language() );
+                }
 
                 // Create translations if not already exists
                 foreach ( $languages as $language ) {
@@ -371,9 +376,6 @@ if ( !class_exists( 'PIP_Patterns' ) ) {
 
                 if ( function_exists( 'pll_set_post_language' ) && function_exists( 'pll_save_post_translations' ) ) {
 
-                    // Set language of main post to default value
-                    pll_set_post_language( $template_post_id, pll_default_language() );
-
                     // Browse translations to set languages
                     foreach ( $available_translations as $language => $value ) {
                         pll_set_post_language( $value, $language );
@@ -395,11 +397,14 @@ if ( !class_exists( 'PIP_Patterns' ) ) {
         private function auto_populate_taxonomies_polylang( $taxonomy, $template_post_id, $template_post_type ) {
 
             // Polylang Compatibility - Create translations
-            if ( is_plugin_active( 'polylang/polylang.php' ) && function_exists( 'pll_languages_list' ) ) {
+            if ( function_exists( 'pll_languages_list' ) ) {
 
                 $languages              = pll_languages_list();
                 $taxonomy_object        = get_taxonomy( $taxonomy );
                 $available_translations = array();
+
+                // Set language of main post to default value
+                pll_set_post_language( $template_post_id, pll_default_language() );
 
                 // Create translations if not already exists
                 foreach ( $languages as $language ) {
@@ -423,9 +428,6 @@ if ( !class_exists( 'PIP_Patterns' ) ) {
                 }
 
                 if ( function_exists( 'pll_set_post_language' ) && function_exists( 'pll_save_post_translations' ) ) {
-
-                    // Set language of main post to default value
-                    pll_set_post_language( $template_post_id, pll_default_language() );
 
                     // Browse translations to set languages
                     foreach ( $available_translations as $language => $value ) {


### PR DESCRIPTION
There was multiple issues regarding generation of "patterns" with Polylang.

1. Having **Polylang Pro** didn't trigger Pilo'Press Polylang compatibility _(because of `is_plugin_active()` use)_
2. There was also an issue causing patterns to generate more than it should have _(ex: 1 CPT with 3 languages was generating 8 posts instead of 4 because of the original post not being set default language before generating translations)_